### PR TITLE
Fixes an isue where racadm is unable to find the SSL library in its default path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ FROM centos
 COPY bootstrap.cgi /tmp/
 
 RUN yum -y update \
- && yum -y install openssl pciutils wget \
+ && yum -y install openssl openssl-devel pciutils wget \
  && bash /tmp/bootstrap.cgi \
  && yum install -y srvadmin-idracadm7.x86_64 -y \
- && ln -s /usr/lib64/libssl.so.1.0.2k /usr/lib64/libssl.so \
  && yum -y clean all
 
 COPY boot-from-iso.sh /boot-from-iso.sh


### PR DESCRIPTION
The following PR Fixes: #1  where openssl-devel package is missing and also removed the symbolic link as it is not required and actually errors since the file exists when you install openssl-devel. 